### PR TITLE
resolution: use grades API first to get the most recent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
  # UBC Transcript Chrome Extension
 
-Prettifies the UBC SSC Grades page. Instead of paying 11$ for a transcript with course names, this does the job.  
+Prettifies the UBC SSC Grades page. Instead of paying 11$ for a transcript with course names, this does the job.
 
 ## Instructions
 
- 1. (a) Install official chrome extension [link here](https://chrome.google.com/webstore/detail/ubc-transcript/kcpilaggggglnjckpcckpngnikfceonn?hl=en&authuser=0). (b) Or download the release manifest.zip and follow [the steps here](https://webkul.com/blog/how-to-install-the-unpacked-extension-in-chrome/). 
+ 1. (a) Install official chrome extension [link here](https://chrome.google.com/webstore/detail/ubc-transcript/kcpilaggggglnjckpcckpngnikfceonn?hl=en&authuser=0). (b) Or download the release manifest.zip and follow [the steps here](https://webkul.com/blog/how-to-install-the-unpacked-extension-in-chrome/).
  2. (Optional) Pin the extension if needed
  3. Go to your [**Grades Summary**](https://ssc.adm.ubc.ca/sscportal/servlets/SRVSSCFramework?function=SessGradeRpt) page.
  4. Click on the extension to run!
@@ -13,8 +13,8 @@ Prettifies the UBC SSC Grades page. Instead of paying 11$ for a transcript with 
  ## Credits
 
 Huge thanks to Charles Clayton (1) and Arash Outadi (2) for previous code and Donney Fan (3) for exposing his UBC Grades backend for API access.
- 
- 1. https://github.com/crclayton/ubc-unofficial-transcript-exporter        
+
+ 1. https://github.com/crclayton/ubc-unofficial-transcript-exporter
  2. https://github.com/arashout/ubc-courses
  3. https://ubcgrades.com/api
 
@@ -22,10 +22,10 @@ Huge thanks to Charles Clayton (1) and Arash Outadi (2) for previous code and Do
  -  Made some modifications to convert js bookmarklet to a chrome extension
  -  Fixed CORS error (see top of background.js) preventing GET requests from both in console and bookmarklet to be run
  -  Changed API server to ubcgrades.com (hopefully it doesn't go down)
- 
+
 ## How it does this:
  1. Adds a course names column and removes unnecessary columns
- 2. Spacing items out better and increasing the width of the table 
+ 2. Spacing items out better and increasing the width of the table
 
 ### Extension
 The extension is JavaScript code that runs on the user's browser to:
@@ -36,7 +36,7 @@ The extension is JavaScript code that runs on the user's browser to:
 
 ## Output
 
-The code gets rid of the extra tabs/average calculator app, spaces things out a little better, and aligns the table to the header. 
+The code gets rid of the extra tabs/average calculator app, spaces things out a little better, and aligns the table to the header.
 
 ![After Transcript Example](https://github.com/arashout/ubc-courses/blob/master/examples/After.png "After Transcript Example")
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "UBC Transcript",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Alternative to the bookmarklet which doesn't work because (a) server is down and (b) content security policy from chrome blocks it.",
     "host_permissions": [ "https://ubcgrades.com/*"],
     "permissions": ["activeTab", "scripting"],
@@ -14,8 +14,8 @@
         "48": "images/santa_48.png",
         "128": "images/santa_128.png"
       },
-      "default_title": "UBC SSC Transcript"  
+      "default_title": "UBC SSC Transcript"
     },
-    
+
     "manifest_version": 3
   }


### PR DESCRIPTION
Using the statistics API appears to return data for the first instance of a course, even if the course is no longer active.

For example, see MECH 423:
```
λ › curl -s https://ubcgrades.com/api/v2/course-statistics/UBCV/MECH/423 | grep course_title
  "course_title": "Biomechatronics",
λ › curl -s https://ubcgrades.com/api/v2/grades/UBCV/2015W/MECH/423/OVERALL | grep course_title
  "course_title": "Biomechatronics",
λ › curl -s https://ubcgrades.com/api/v2/grades/UBCV/2016W/MECH/423/OVERALL | grep course_title
  "course_title": "Mechatronic Product Design",
```

Assuming this isn't an error with UBC Grades I have no idea why UBC would choose to reuse a course code like this.

In any case, it's probably best to try and use the grades API where possible to get the most accurate name.